### PR TITLE
UnitData temperature

### DIFF
--- a/doc/parsers.rst
+++ b/doc/parsers.rst
@@ -107,6 +107,8 @@ velocities):
        length_conversion=1.0,
        volume_str='nm^3',
        volume_conversion=1.0,
+       temperature_str='K',
+       temperature_conversion=1.0,
        pressure_str='bar',
        pressure_conversion=1.0,
        time_str='ps',
@@ -163,6 +165,8 @@ velocities):
        length_conversion=1.0,
        volume_str='nm^3',
        volume_conversion=1.0,
+       temperature_str='K',
+       temperature_conversion=1.0,
        pressure_str='bar',
        pressure_conversion=1.0,
        time_str='ps',
@@ -206,18 +210,20 @@ Attributes:
 * :attr:`.UnitData.energy_conversion`, `float`
 * :attr:`.UnitData.length_conversion`, `float`
 * :attr:`.UnitData.volume_conversion`, `float`
+* :attr:`.UnitData.temperature_conversion`, `float`
 * :attr:`.UnitData.pressure_conversion`, `float`
 * :attr:`.UnitData.time_conversion`, `float`
 * :attr:`.UnitData.energy_str`, `str`
 * :attr:`.UnitData.length_str`, `str`
 * :attr:`.UnitData.volume_str`, `str`
+* :attr:`.UnitData.temperature_str`, `str`
 * :attr:`.UnitData.pressure_str`, `str`
 * :attr:`.UnitData.time_str`, `str`
 
 The information about units consists of different parts:
 * The value of kB in the used energy units,
-* the conversion factor to GROMACS units (kJ/mol, nm, nm^3, bar, ps), and
-* the name of the units (energy_str, length_str, volume_str, pressure_str, time_str).
+* the conversion factor to GROMACS units (kJ/mol, nm, nm^3, K, bar, ps), and
+* the name of the units (energy_str, length_str, volume_str, temperature_str, pressure_str, time_str).
 The names are only used for output (console printing and plotting), and are optional.
 The conversion factors and kB are, on the other hand, used in computations and need
 to be given.

--- a/physical_validation/data/gromacs_parser.py
+++ b/physical_validation/data/gromacs_parser.py
@@ -61,6 +61,8 @@ class GromacsParser(parser.Parser):
             length_conversion=1.0,
             volume_str='nm^3',
             volume_conversion=1.0,
+            temperature_str='K',
+            temperature_conversion=1.0,
             pressure_str='bar',
             pressure_conversion=1.0,
             time_str='ps',

--- a/physical_validation/data/unit_data.py
+++ b/physical_validation/data/unit_data.py
@@ -34,17 +34,18 @@ class UnitData(object):
     r"""UnitData: Information about the units used
 
     The information about units consists of different parts:
-    * The name of the units (energy_str, length_str, volume_str, pressure_str, time_str),
+    * The name of the units (energy_str, length_str, volume_str,
+                             temperature_str, pressure_str, time_str),
     * the value of kB in the used energy units, and
-    * the conversion factor to GROMACS units (kJ/mol, nm, nm^3, bar, ps).
+    * the conversion factor to GROMACS units (kJ/mol, nm, nm^3, K, bar, ps).
     The names are only used for output (console printing and plotting), and are optional.
     The conversion factors and kB are, on the other hand, used in computations and need
     to be given.
     """
-    def __init__(self, kb, energy_conversion, length_conversion,
-                 volume_conversion, pressure_conversion, time_conversion,
-                 energy_str='ENE', length_str='LEN',
-                 volume_str='VOL', pressure_str='PRESS', time_str='TIME'):
+    def __init__(self, kb, energy_conversion, length_conversion, volume_conversion,
+                 temperature_conversion, pressure_conversion, time_conversion,
+                 energy_str='ENE', length_str='LEN', volume_str='VOL',
+                 temperature_str='TEMP', pressure_str='PRESS', time_str='TIME'):
 
         self.__kb = float(kb)
         self.__energy_str = str(energy_str)
@@ -53,6 +54,8 @@ class UnitData(object):
         self.__length_conversion = float(length_conversion)
         self.__volume_str = str(volume_str)
         self.__volume_conversion = float(volume_conversion)
+        self.__temperature_str = str(temperature_str)
+        self.__temperature_conversion = float(temperature_conversion)
         self.__pressure_str = str(pressure_str)
         self.__pressure_conversion = float(pressure_conversion)
         self.__time_str = str(time_str)
@@ -66,6 +69,7 @@ class UnitData(object):
                 self.energy_conversion == other.energy_conversion and
                 self.length_conversion == other.length_conversion and
                 self.volume_conversion == other.volume_conversion and
+                self.temperature_conversion == other.temperature_conversion and
                 self.pressure_conversion == other.pressure_conversion and
                 self.time_conversion == other.time_conversion)
 
@@ -88,6 +92,11 @@ class UnitData(object):
     def volume_str(self):
         """str: Volume unit"""
         return self.__volume_str
+
+    @property
+    def temperature_str(self):
+        """str: Temperature unit"""
+        return self.__temperature_str
 
     @property
     def pressure_str(self):
@@ -113,6 +122,11 @@ class UnitData(object):
     def volume_conversion(self):
         """float: Volume conversion factor: 1 volume_unit = volume_conversion * nm^3"""
         return self.__volume_conversion
+
+    @property
+    def temperature_conversion(self):
+        """float: Time conversion factor: 1 temperature_unit = temperature_conversion * ps"""
+        return self.__temperature_conversion
 
     @property
     def pressure_conversion(self):


### PR DESCRIPTION
For some reason, UnitData did not contain any information about the
used temperature units. This commit fixes this.